### PR TITLE
Clean up ports in `.gitpod.yml`

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -70,6 +70,9 @@ ports:
   # Currently un-notified and unsupported mailhog https port
   - port: 8027
     onOpen: ignore
+  # Currently un-notified and unsupported phpmyadmin http port
+  - port: 8036
+    onOpen: ignore
   # xdebug port
   - port: 9000
     onOpen: ignore

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -64,14 +64,13 @@ ports:
   # Ignore host https port
   - port: 8443
     onOpen: ignore
+  - port: 3306
+    onOpen: ignore
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
     onOpen: ignore
   # Currently un-notified and unsupported mailhog https port
   - port: 8027
-    onOpen: ignore
-  # Currently un-notified and unsupported phpmyadmin http port
-  - port: 8036
     onOpen: ignore
   # xdebug port
   - port: 9000

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -64,34 +64,12 @@ ports:
   # Ignore host https port
   - port: 8443
     onOpen: ignore
-  - port: 3306
-    onOpen: ignore
-  # Used by projector
-  - port: 6942
-    onOpen: ignore
   # Direct-connect ddev-webserver port that is the main port
   - port: 8080
     onOpen: ignore
-  # Currently un-notified and unsupported mailhog http port
-  - port: 8025
-    onOpen: ignore
   # Currently un-notified and unsupported mailhog https port
-  - port: 8026
-    onOpen: ignore
-  # Currently un-notified and unsupported phpmyadmin http port
-  - port: 8036
-    onOpen: ignore
-  # Currently un-notified and unsupported phpmyadmin https port
-  - port: 8037
-    onOpen: ignore
-  # router http port that we're ignoring.
-  - port: 8888
-    onOpen: ignore
-  # router https port that we're ignoring.
-  - port: 8889
+  - port: 8027
     onOpen: ignore
   # xdebug port
   - port: 9000
     onOpen: ignore
-  # projector port
-  - port: 9999


### PR DESCRIPTION
## The Problem/Issue/Bug:

Many ports belong to previous setup that is no longer needed in current ddev workspace in Gitpod.
Each port that is defined in `.gitpod.yml`, is added to the list of ports, and can be confusing for users -
![image](https://user-images.githubusercontent.com/22901/144966035-2f2c8d1f-9e5a-418e-adbe-a3d4a73f16d3.png)


## How this PR Solves The Problem:

## Manual Testing Instructions:

## Automated Testing Overview:
<!-- Please provide an overview of tests introduced by this PR, or an explanation for why no tests are needed. -->

## Related Issue Link(s):

## Release/Deployment notes:
<!-- Does this affect anything else, or are there ramifications for other code? Does anything have to be done on deployment? -->



<a href="https://gitpod.io/#https://github.com/drud/ddev/pull/3427"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>



<a href="https://gitpod.io/#https://github.com/rfay/ddev/pull/13"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

